### PR TITLE
Add ability to find and cancel supervised job by id/name. 

### DIFF
--- a/lib/sched_ex.ex
+++ b/lib/sched_ex.ex
@@ -19,8 +19,8 @@ defmodule SchedEx do
   end
 
   @doc """
-  Runs the given module, function and argument in given number of units (this 
-  corresponds to milliseconds unless a custom `time_scale` is specified). Any 
+  Runs the given module, function and argument in given number of units (this
+  corresponds to milliseconds unless a custom `time_scale` is specified). Any
   values in the arguments array which are equal to the magic symbol `:sched_ex_scheduled_time`
   are replaced with the scheduled execution time for each invocation
 
@@ -29,17 +29,19 @@ defmodule SchedEx do
   * `repeat`: Whether or not this job should be recurring
   * `start_time`: A `DateTime` to use as the basis to offset from
   * `time_scale`: A module implementing one method: `speedup/0`, which returns a
-  float factor to speed up delays by. Used mostly for speeding up test runs. 
-  If not specified, defaults to an identity module which returns a value of 1, 
+  float factor to speed up delays by. Used mostly for speeding up test runs.
+  If not specified, defaults to an identity module which returns a value of 1,
   such that this method runs the job in 'delay' ms
+  * `name`: To attach a name to the process. Useful for adding a name to Registry
+  to lookup later. ie. {:via, Registry, {YourRegistryName, "scheduled-task-1"}}
   """
   def run_in(m, f, a, delay, opts \\ []) when is_atom(m) and is_atom(f) and is_list(a) do
     run_in(mfa_to_fn(m, f, a), delay, opts)
   end
 
   @doc """
-  Runs the given function in given number of units (this corresponds to milliseconds 
-  unless a custom `time_scale` is specified). If func is of arity 1, the scheduled 
+  Runs the given function in given number of units (this corresponds to milliseconds
+  unless a custom `time_scale` is specified). If func is of arity 1, the scheduled
   execution time will be passed for each invocation
 
   Supports the following options:
@@ -47,9 +49,11 @@ defmodule SchedEx do
   * `repeat`: Whether or not this job should be recurring. Defaults to false
   * `start_time`: A `DateTime` to use as the basis to offset from
   * `time_scale`: A module implementing one method: `speedup/0`, which returns a
-  float factor to speed up delays by. Used mostly for speeding up test runs. 
-  If not specified, defaults to an identity module which returns a value of 1, 
+  float factor to speed up delays by. Used mostly for speeding up test runs.
+  If not specified, defaults to an identity module which returns a value of 1,
   such that this method runs the job in 'delay' ms
+  * `name`: To attach a name to the process. Useful for adding a name to Registry
+  to lookup later. ie. {:via, Registry, {YourRegistryName, "scheduled-task-1"}}
   """
   def run_in(func, delay, opts \\ []) when is_function(func) and is_integer(delay) do
     SchedEx.Runner.run(func, delay, opts)
@@ -62,28 +66,32 @@ defmodule SchedEx do
 
   Supports the following options:
 
-  * `timezone`: A string timezone identifier (`America/Chicago`) specifying the timezone within which 
+  * `timezone`: A string timezone identifier (`America/Chicago`) specifying the timezone within which
   the crontab should be interpreted. If not specified, defaults to `UTC`
-  * `time_scale`: A module implementing two methods: `now/1`, which returns the current time in the specified timezone, and 
-  `speedup/0`, which returns a float factor to speed up delays by. Used mostly for speeding up test runs. If not specified, defaults to 
+  * `time_scale`: A module implementing two methods: `now/1`, which returns the current time in the specified timezone, and
+  `speedup/0`, which returns a float factor to speed up delays by. Used mostly for speeding up test runs. If not specified, defaults to
   an identity module which returns 'now', and a factor of 1
+  * `name`: To attach a name to the process. Useful for adding a name to Registry
+  to lookup later. ie. {:via, Registry, {YourRegistryName, "scheduled-task-1"}}
   """
   def run_every(m, f, a, crontab, opts \\ []) when is_atom(m) and is_atom(f) and is_list(a) do
     run_every(mfa_to_fn(m, f, a), crontab, opts)
   end
 
   @doc """
-  Runs the given function on every occurence of the given crontab. If func is of arity 1, the 
+  Runs the given function on every occurence of the given crontab. If func is of arity 1, the
   scheduled execution time will be passed for each invocation
 
   Supports the following options:
 
-  * `timezone`: A string timezone identifier (`America/Chicago`) specifying the timezone within which 
+  * `timezone`: A string timezone identifier (`America/Chicago`) specifying the timezone within which
   the crontab should be interpreted. If not specified, defaults to `UTC`
-  * `time_scale`: A module implementing two methods: `now/1`, which returns the current time in the specified timezone, and 
-  `speedup/0`, which returns an integer factor to speed up delays by. Used mostly for speeding up test runs. If not specified, defaults to 
+  * `time_scale`: A module implementing two methods: `now/1`, which returns the current time in the specified timezone, and
+  `speedup/0`, which returns an integer factor to speed up delays by. Used mostly for speeding up test runs. If not specified, defaults to
   an identity module which returns 'now', and a factor of 1
   * `repeat`: Whether or not this job should be recurring. If false, only the next matching time of the crontab is executed. Defaults to true
+  * `name`: To attach a name to the process. Useful for adding a name to Registry
+  to lookup later. ie. {:via, Registry, {YourRegistryName, "scheduled-task-1"}}
   """
   def run_every(func, crontab, opts \\ []) when is_function(func) do
     case as_crontab(crontab) do
@@ -106,8 +114,8 @@ defmodule SchedEx do
   Returns stats on the given job. Stats are returned for:
   * `scheduling_delay`: The delay between when the job was scheduled to execute, and the time
   it actually was executed. Based on the quantized scheduled start, and so does not include quantization error. Value specified in microseconds.
-  * `quantization_error`: Erlang is only capable of scheduling future calls with millisecond precision, so there is some 
-  inevitable precision lost between when the job would be scheduled in a perfect world, and how well Erlang is able to 
+  * `quantization_error`: Erlang is only capable of scheduling future calls with millisecond precision, so there is some
+  inevitable precision lost between when the job would be scheduled in a perfect world, and how well Erlang is able to
   schedule the job (ie: to the closest millisecond). This error value captures that difference. Value specified in microseconds.
   * `execution_time`: The amount of time the job spent executing. Value specified in microseconds.
 

--- a/lib/sched_ex/runner.ex
+++ b/lib/sched_ex/runner.ex
@@ -9,7 +9,12 @@ defmodule SchedEx.Runner do
   unit as derived from a TimeScale, or a CronExpression)
   """
   def run(func, delay_definition, opts) when is_function(func) do
-    GenServer.start_link(__MODULE__, {func, delay_definition, opts})
+    name = Keyword.get(opts, :name)
+    if name do 
+      GenServer.start_link(__MODULE__, {func, delay_definition, opts}, name: name)
+    else
+      GenServer.start_link(__MODULE__, {func, delay_definition, opts})
+    end
   end
 
   @doc """

--- a/lib/sched_ex/runner.ex
+++ b/lib/sched_ex/runner.ex
@@ -5,20 +5,15 @@ defmodule SchedEx.Runner do
 
   @doc """
   Main point of entry into this module. Starts and returns a process which will
-  run the given function per the specified delay definition (can be an integer 
+  run the given function per the specified delay definition (can be an integer
   unit as derived from a TimeScale, or a CronExpression)
   """
   def run(func, delay_definition, opts) when is_function(func) do
-    name = Keyword.get(opts, :name)
-    if name do 
-      GenServer.start_link(__MODULE__, {func, delay_definition, opts}, name: name)
-    else
-      GenServer.start_link(__MODULE__, {func, delay_definition, opts})
-    end
+    GenServer.start_link(__MODULE__, {func, delay_definition, opts}, Keyword.take(opts, [:name]))
   end
 
   @doc """
-  Returns stats for the given process. 
+  Returns stats for the given process.
   """
   def stats(pid) when is_pid(pid) do
     GenServer.call(pid, :stats)


### PR DESCRIPTION
Hey! Thanks for the great library!

I'm not sure if this is the best way to solve this, but I wanted to be able to look up a recurring job and cancel it. This pull request adds the ability to pass a name as an option which can be used by gproc or Registry to name a job, so it can be looked up and cancelled later. 