### PR TITLE
Handle and ignore {:EXIT, pid, :normal} messages

### DIFF
--- a/lib/sched_ex/runner.ex
+++ b/lib/sched_ex/runner.ex
@@ -108,6 +108,10 @@ defmodule SchedEx.Runner do
   def handle_info(:shutdown, state) do
     {:stop, :normal, state}
   end
+  
+  def handle_info({:EXIT, _pid, :normal}, state) do
+    {:noreply, state}
+  end
 
   defp schedule_next(%DateTime{} = from, delay, opts) when is_integer(delay) do
     time_scale = Keyword.get(opts, :time_scale, SchedEx.IdentityTimeScale)


### PR DESCRIPTION
Because SchedEx.Runner traps exits, it will receive these {:EXIT, pid, reason} messages from linked processes. Currently, this will cause Schedex.Runner to crash with "no clause matching handle_info({:EXIT, pid, reason}, state)".

In my opinion, SchedEx should ignore these messages when the exit reason is :normal. This is especially important, because many of periodical tasks do something like sending an email, or interacting with some external APIs, and these things tend to be done in a separate process by many libraries.