### PR TITLE
Add a timescale behaviour

### DIFF
--- a/lib/sched_ex.ex
+++ b/lib/sched_ex.ex
@@ -28,10 +28,9 @@ defmodule SchedEx do
 
   * `repeat`: Whether or not this job should be recurring
   * `start_time`: A `DateTime` to use as the basis to offset from
-  * `time_scale`: A module implementing one method: `speedup/0`, which returns a
-  float factor to speed up delays by. Used mostly for speeding up test runs.
-  If not specified, defaults to an identity module which returns a value of 1,
-  such that this method runs the job in 'delay' ms
+  * `time_scale`: A module that implements the `SchedEx.TimeScale` behaviour, by
+  default is set to `SchedEx.IdentityTimeScale`. Can be used to speed up time
+  (often used for speeding up test runs)
   * `name`: To attach a name to the process. Useful for adding a name to Registry
   to lookup later. ie. {:via, Registry, {YourRegistryName, "scheduled-task-1"}}
   """
@@ -68,9 +67,9 @@ defmodule SchedEx do
 
   * `timezone`: A string timezone identifier (`America/Chicago`) specifying the timezone within which
   the crontab should be interpreted. If not specified, defaults to `UTC`
-  * `time_scale`: A module implementing two methods: `now/1`, which returns the current time in the specified timezone, and
-  `speedup/0`, which returns a float factor to speed up delays by. Used mostly for speeding up test runs. If not specified, defaults to
-  an identity module which returns 'now', and a factor of 1
+  * `time_scale`: A module that implements the `SchedEx.TimeScale` behaviour, by
+  default is set to `SchedEx.IdentityTimeScale`. Can be used to speed up time
+  (often used for speeding up test runs)
   * `name`: To attach a name to the process. Useful for adding a name to Registry
   to lookup later. ie. {:via, Registry, {YourRegistryName, "scheduled-task-1"}}
   """

--- a/lib/sched_ex/identity_time_scale.ex
+++ b/lib/sched_ex/identity_time_scale.ex
@@ -1,10 +1,15 @@
 defmodule SchedEx.IdentityTimeScale do
-  @moduledoc false
+  @moduledoc """
+  The default module used to set the `time_scale`. Can be thought of as "normal time" where "now" is now and speedup is 1 (no speedup)
+  """
+  @behaviour SchedEx.TimeScale
 
+  @impl true
   def now(timezone) do
     Timex.now(timezone)
   end
 
+  @impl true
   def speedup do
     1
   end

--- a/lib/sched_ex/time_scale.ex
+++ b/lib/sched_ex/time_scale.ex
@@ -1,0 +1,18 @@
+defmodule SchedEx.TimeScale do
+  @moduledoc """
+  Constrols time in SchedEx, often used to speed up test runs, or implement
+  custom timing loops.
+
+  Default implementation is `SchedEx.IdentityTimeScale`
+  """
+
+  @doc """
+  Must return the current time in the specified timezone
+  """
+  @callback now(Timex.Types.valid_timezone()) :: DateTime.t()
+
+  @doc """
+  Must returns a float factor to speed up delays by
+  """
+  @callback speedup() :: number
+end


### PR DESCRIPTION
Makes it more obvious and explicit what is needed to implement a custom timescale.

I wasn't sure if `now/1` should be marked as optional.