### PR TITLE
Handle exits

### DIFF
--- a/lib/sched_ex/runner.ex
+++ b/lib/sched_ex/runner.ex
@@ -108,6 +108,10 @@ defmodule SchedEx.Runner do
   def handle_info(:shutdown, state) do
     {:stop, :normal, state}
   end
+  
+  def handle_info({:EXIT, _pid, :normal}, state) do
+    {:noreply, state}
+  end
 
   defp schedule_next(%DateTime{} = from, delay, opts) when is_integer(delay) do
     time_scale = Keyword.get(opts, :time_scale, SchedEx.IdentityTimeScale)


### PR DESCRIPTION
This is an attempt to add a test for #5. I've run into this issue before, but I had trouble getting the runner to receive an exit message from the scheduled function.

My test ended up just creating a timer, sending a message to it, and ensuring it didn't invoke a crash. While it works (I pulled it in as a git dependency on a work project), it doesn't feel like a good test.

If you have suggestions or revisions, I'm more than happy to adjust.

(Also, if it's bad form to open a second PR for this, I can amend that too.)