### PR TITLE
fix: support 1.2 of crontab

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule SchedEx.Mixfile do
 
   defp deps do
     [
-      {:crontab, "~> 1.1.2"},
+      {:crontab, "~> 1.1"},
       {:timex, "~> 3.1"},
       {:ex_doc, ">= 0.0.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
Fixes warning when wanting 1.2 of crontab. Allows usage of 1.1 and higher, whereas before 1.2 was not allowed.