### PR TITLE
fix: avoid crash with default timezone

### DIFF
--- a/lib/sched_ex/runner.ex
+++ b/lib/sched_ex/runner.ex
@@ -127,7 +127,7 @@ defmodule SchedEx.Runner do
 
   defp schedule_next(_from, crontab, opts) do
     time_scale = Keyword.get(opts, :time_scale, SchedEx.IdentityTimeScale)
-    timezone = Keyword.get(opts, :timezone, "UTC")
+    timezone = Keyword.get(opts, :timezone, "Etc/UTC")
     now = time_scale.now(timezone)
 
     case next_occurrence(now, crontab, timezone, opts) do

--- a/test/sched_ex_test.exs
+++ b/test/sched_ex_test.exs
@@ -317,7 +317,7 @@ defmodule SchedExTest do
       {:ok, expected_naive_time} =
         Crontab.Scheduler.get_next_run_date(crontab, NaiveDateTime.utc_now())
 
-      expected_time = DateTime.from_naive!(expected_naive_time, "UTC")
+      expected_time = DateTime.from_naive!(expected_naive_time, "Etc/UTC")
 
       SchedEx.run_every(
         TestCallee,
@@ -338,7 +338,7 @@ defmodule SchedExTest do
       {:ok, expected_naive_time} =
         Crontab.Scheduler.get_next_run_date(crontab, NaiveDateTime.utc_now())
 
-      expected_time = DateTime.from_naive!(expected_naive_time, "UTC")
+      expected_time = DateTime.from_naive!(expected_naive_time, "Etc/UTC")
 
       SchedEx.run_every(
         fn time -> TestCallee.append(context.agent, time) end,


### PR DESCRIPTION
#60 drops timex in favor of DateTime, but doesn't update the default "UTC" timezone to "Etc/UTC" (ref: https://elixir.hexdocs.pm/DateTime.html#now/2)